### PR TITLE
Fix account detail retrieval

### DIFF
--- a/AccountService/src/main/java/com/company/accountservice/mappers/AccountMapper.java
+++ b/AccountService/src/main/java/com/company/accountservice/mappers/AccountMapper.java
@@ -2,6 +2,7 @@ package com.company.accountservice.mappers;
 
 import com.company.accountservice.domain.Account;
 import com.company.accountservice.dto.AccountDto;
+import com.company.accountservice.dto.AccountDetailDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
@@ -11,5 +12,7 @@ import org.mapstruct.ReportingPolicy;
 public interface AccountMapper extends BaseMapper<Account, AccountDto> {
 
     void updateEntityFromDto(AccountDto dto, @MappingTarget Account entity);
+
+    AccountDetailDto toDetailDto(Account entity);
 
 }

--- a/AccountService/src/main/java/com/company/accountservice/mappers/CustomerMapper.java
+++ b/AccountService/src/main/java/com/company/accountservice/mappers/CustomerMapper.java
@@ -8,4 +8,6 @@ import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CustomerMapper extends BaseMapper<Customer, CustomerDto> {
+
+    CustomerDto toDto(Customer entity);
 }

--- a/AccountService/src/main/java/com/company/accountservice/service/AccountService.java
+++ b/AccountService/src/main/java/com/company/accountservice/service/AccountService.java
@@ -49,7 +49,13 @@ public class AccountService {
 
     @Transactional
     public AccountDetailDto get(Long id) {
-        return accountRepository.findById(id).map(account -> new AccountDetailDto()).orElseThrow(() -> new RuntimeException("Account not found with id: " + id));
+        return accountRepository.findById(id)
+                .map(account -> {
+                    AccountDetailDto dto = accountMapper.toDetailDto(account);
+                    dto.setCustomer(customerService.get(account.getCustomerId()));
+                    return dto;
+                })
+                .orElseThrow(() -> new RuntimeException("Account not found with id: " + id));
     }
 
     public String getBuildVersion() {

--- a/AccountService/src/main/java/com/company/accountservice/service/CustomerService.java
+++ b/AccountService/src/main/java/com/company/accountservice/service/CustomerService.java
@@ -34,4 +34,11 @@ public class CustomerService {
         customer.setPhoneNumber(customerDto.getCustomerPhone());
         return customerRepository.save(customer).getId();
     }
+
+    @Transactional
+    public CustomerDto get(Long id) {
+        return customerRepository.findById(id)
+                .map(customerMapper::toDto)
+                .orElseThrow(() -> new RuntimeException("Customer not found with id: " + id));
+    }
 }

--- a/AccountService/src/test/java/com/company/accountservice/AccountServiceTests.java
+++ b/AccountService/src/test/java/com/company/accountservice/AccountServiceTests.java
@@ -1,0 +1,49 @@
+import com.company.accountservice.domain.Account;
+import com.company.accountservice.dto.AccountDetailDto;
+import com.company.accountservice.dto.CustomerDto;
+import com.company.accountservice.mappers.AccountMapper;
+import com.company.accountservice.repository.AccountRepository;
+import com.company.accountservice.service.AccountService;
+import com.company.accountservice.service.CustomerService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AccountServiceTests {
+
+    @Mock
+    AccountRepository accountRepository;
+    @Mock
+    AccountMapper accountMapper;
+    @Mock
+    CustomerService customerService;
+    @InjectMocks
+    AccountService accountService;
+
+    @Test
+    void getReturnsAccountWithCustomer() {
+        Account account = new Account();
+        account.setId(1L);
+        account.setCustomerId(2L);
+
+        AccountDetailDto detailDto = new AccountDetailDto();
+        CustomerDto customerDto = new CustomerDto("name", "email", "phone");
+        detailDto.setCustomer(customerDto);
+
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(account));
+        when(accountMapper.toDetailDto(account)).thenReturn(detailDto);
+        when(customerService.get(2L)).thenReturn(customerDto);
+
+        AccountDetailDto result = accountService.get(1L);
+        assertSame(detailDto, result);
+        assertSame(customerDto, result.getCustomer());
+    }
+}


### PR DESCRIPTION
## Summary
- add mapping from `Account` entity to `AccountDetailDto`
- expose conversion from `Customer` entity to DTO
- implement `AccountService#get` using new mappers and add `CustomerService#get`
- add unit test for updated `AccountService#get`

## Testing
- `./mvnw -q -e -DskipTests=false test` *(fails: wget failed to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68486a50a0c4832abe4ca0b547807b10