### PR TITLE
Fix configserver URLs in services

### DIFF
--- a/AccountService/src/main/resources/application.yml
+++ b/AccountService/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
       ddl-auto: update
     show-sql: true
   config:
-    import: "configserver:http://localhost:8071" # we can add optional property
+    import: "configserver:http://configserver:8071" # we can add optional property
 
   rabbitmq:
     host: ${SPRING_RABBIT_MQ_HOST}

--- a/card/src/main/resources/application.yml
+++ b/card/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
       ddl-auto: update
     show-sql: true
   config:
-    import: "configserver:http://localhost:8071"
+    import: "configserver:http://configserver:8071"
 
   rabbitmq:
     host: ${SPRING_RABBIT_MQ_HOST}

--- a/loan/src/main/resources/application.yml
+++ b/loan/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
       ddl-auto: update
     show-sql: true
   config:
-    import: "configserver:http://localhost:8071"
+    import: "configserver:http://configserver:8071"
 
   rabbitmq:
     host: ${SPRING_RABBIT_MQ_HOST}


### PR DESCRIPTION
## Summary
- update the `spring.config.import` URLs to reference `configserver` container for AccountService, card, and loan services

## Testing
- `./mvnw -q test` (fails: unable to fetch Maven dependencies)

------
https://chatgpt.com/codex/tasks/task_e_684912fcff0c832a843adbf2e9cd4c21