### PR TITLE
Fix RabbitMQ host env variable

### DIFF
--- a/AccountService/src/main/resources/application.yml
+++ b/AccountService/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
     import: "configserver:http://localhost:8071" # we can add optional property
 
   rabbitmq:
-    host: ${SPRING_RABBIT_MQ_HOST}
+    host: ${SPRING_RABBITMQ_HOST}
     password: guest
     username: guest
     port: 5672

--- a/card/src/main/resources/application.yml
+++ b/card/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     import: "configserver:http://localhost:8071"
 
   rabbitmq:
-    host: ${SPRING_RABBIT_MQ_HOST}
+    host: ${SPRING_RABBITMQ_HOST}
     password: guest
     username: guest
     port: 5672

--- a/loan/src/main/resources/application.yml
+++ b/loan/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     import: "configserver:http://localhost:8071"
 
   rabbitmq:
-    host: ${SPRING_RABBIT_MQ_HOST}
+    host: ${SPRING_RABBITMQ_HOST}
     password: guest
     username: guest
     port: 5672


### PR DESCRIPTION
## Summary
- update RabbitMQ host environment variable in `application.yml`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68491305b650832aa1090f85195a7c61