### PR TITLE
Handle missing RabbitMQ host var

### DIFF
--- a/AccountService/src/main/resources/application.yml
+++ b/AccountService/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
     import: "configserver:http://configserver:8071" # we can add optional property
 
   rabbitmq:
-    host: ${SPRING_RABBITMQ_HOST}
+    host: ${SPRING_RABBITMQ_HOST:localhost}
     password: guest
     username: guest
     port: 5672

--- a/card/src/main/resources/application.yml
+++ b/card/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     import: "configserver:http://configserver:8071"
 
   rabbitmq:
-    host: ${SPRING_RABBITMQ_HOST}
+    host: ${SPRING_RABBITMQ_HOST:localhost}
     password: guest
     username: guest
     port: 5672

--- a/configserver/src/main/resources/application.yml
+++ b/configserver/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
           clone-on-start: true
           force-pull: true
   rabbitmq:
-    host: ${SPRING_RABBITMQ_HOST}
+    host: ${SPRING_RABBITMQ_HOST:localhost}
     password: guest
     username: guest
     port: 5672

--- a/loan/src/main/resources/application.yml
+++ b/loan/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     import: "configserver:http://configserver:8071"
 
   rabbitmq:
-    host: ${SPRING_RABBITMQ_HOST}
+    host: ${SPRING_RABBITMQ_HOST:localhost}
     password: guest
     username: guest
     port: 5672


### PR DESCRIPTION
## Summary
- provide a default host for RabbitMQ in all services

## Testing
- `./mvnw -q test` *(fails: unable to fetch Maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6849177ef914832a84216204e6f7c261