### PR TITLE
Add Kubernetes deployment resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Bank Application
+
+This repository contains multiple Spring Boot microservices. The `k8s` directory holds Kubernetes manifests for running them in a cluster.
+
+## Running with Kubernetes
+
+1. Ensure container images referenced in the manifests are available (build with Maven Jib or pull from Docker Hub).
+2. Apply all resources:
+
+```bash
+kubectl apply -f k8s/
+```
+
+Each service will be exposed via a `NodePort` defined in its manifest.

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,11 @@
+# Kubernetes manifests
+
+This directory contains Kubernetes resources for running the services that make up the bank application.
+
+Apply all manifests using:
+
+```bash
+kubectl apply -f k8s/
+```
+
+The manifests assume images are available in a registry as referenced in each Deployment.

--- a/k8s/accounts.yaml
+++ b/k8s/accounts.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: accounts
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: accounts
+  template:
+    metadata:
+      labels:
+        app: accounts
+    spec:
+      containers:
+      - name: accounts
+        image: shukhratjon1201/accounts
+        ports:
+        - containerPort: 8080
+        env:
+        - name: SPRING_APPLICATION_NAME
+          value: accounts
+        - name: SPRING_PROFILES_ACTIVE
+          value: default
+        - name: SPRING_CONFIG_IMPORT
+          value: "configserver:http://configserver:8071"
+        - name: SPRING_RABBITMQ_HOST
+          value: rabbitmq
+        resources:
+          limits:
+            memory: "700Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: accounts
+spec:
+  type: NodePort
+  selector:
+    app: accounts
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: 30080

--- a/k8s/cards.yaml
+++ b/k8s/cards.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cards
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cards
+  template:
+    metadata:
+      labels:
+        app: cards
+    spec:
+      containers:
+      - name: cards
+        image: shukhratjon1201/card
+        ports:
+        - containerPort: 9090
+        env:
+        - name: SPRING_APPLICATION_NAME
+          value: cards
+        - name: SPRING_PROFILES_ACTIVE
+          value: default
+        - name: SPRING_CONFIG_IMPORT
+          value: "configserver:http://configserver:8071"
+        - name: SPRING_RABBITMQ_HOST
+          value: rabbitmq
+        resources:
+          limits:
+            memory: "700Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cards
+spec:
+  type: NodePort
+  selector:
+    app: cards
+  ports:
+  - port: 9090
+    targetPort: 9090
+    nodePort: 30090

--- a/k8s/configserver.yaml
+++ b/k8s/configserver.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: configserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: configserver
+  template:
+    metadata:
+      labels:
+        app: configserver
+    spec:
+      containers:
+      - name: configserver
+        image: shukhratjon1201/configserver
+        ports:
+        - containerPort: 8071
+        env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: git
+        - name: SPRING_RABBITMQ_HOST
+          value: rabbitmq
+        resources:
+          limits:
+            memory: "700Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: configserver
+spec:
+  type: NodePort
+  selector:
+    app: configserver
+  ports:
+  - port: 8071
+    targetPort: 8071
+    nodePort: 30071

--- a/k8s/loans.yaml
+++ b/k8s/loans.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loans
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loans
+  template:
+    metadata:
+      labels:
+        app: loans
+    spec:
+      containers:
+      - name: loans
+        image: shukhratjon1201/loan
+        ports:
+        - containerPort: 8090
+        env:
+        - name: SPRING_APPLICATION_NAME
+          value: loans
+        - name: SPRING_PROFILES_ACTIVE
+          value: default
+        - name: SPRING_CONFIG_IMPORT
+          value: "configserver:http://configserver:8071"
+        - name: SPRING_RABBITMQ_HOST
+          value: rabbitmq
+        resources:
+          limits:
+            memory: "700Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loans
+spec:
+  type: NodePort
+  selector:
+    app: loans
+  ports:
+  - port: 8090
+    targetPort: 8090
+    nodePort: 30091

--- a/k8s/rabbitmq.yaml
+++ b/k8s/rabbitmq.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+      - name: rabbitmq
+        image: rabbitmq
+        ports:
+        - containerPort: 5672
+        - containerPort: 15672
+        resources:
+          limits:
+            memory: "700Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+  - name: amqp
+    port: 5672
+    targetPort: 5672
+  - name: management
+    port: 15672
+    targetPort: 15672
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add Kubernetes manifests for accounts, cards, loans, config server and RabbitMQ
- document how to apply these resources

## Testing
- `./mvnw -q -pl AccountService -am test` *(fails: unable to fetch Maven)*
- `./mvnw -q -pl card -am test` *(fails: unable to fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68491dc07100832ab781fe98a816678a